### PR TITLE
Use custom MinifiedThing subclass to prevent ticking with better performance

### DIFF
--- a/Defs/MinifyThingConfigurableTick.xml
+++ b/Defs/MinifyThingConfigurableTick.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+  <ThingDef ParentName="MinifiedThing">
+    <defName>MinifyThingConfigurableTick</defName>
+    <thingClass>MinifyEverything.MinifyThingConfigurableTick</thingClass>
+  </ThingDef>
+</Defs>


### PR DESCRIPTION
This PR adds a custom `MinifiedThing` subclass called "MinifyThingConfigurableTick", which implements Vanilla's `IThingHolderTickable` interface and sets `ShouldTickContents` to match MinifyEverything's setting.

This subclass has a couple advantages:
- We avoid the heavy performance cost of the Harmony patch on `ThingOwner.DoTick`.
- Pre-existing Vanilla and modded minifiable objects can continue ticking, so e.g. batteries can continue to discharge. Ticking is only modified for things updated by MinifyEverything.

I've also added a backwards-compatibility patch that converts pre-existing minified objects to the new subclass if their def was updated by MinifyEverything. This prevents ticking errors in older saves when the `DoTick` patch is removed. Vanilla and modded minified objects aren't affected if they're already minifiable.

I've verified these changes with a heavy mod list, with/without submods like Smart Minify, and with minified items that shouldn't tick. When the tick setting is disabled, the items don't tick. When the tick setting is enabled, the items start ticking again. New minified objects are built as `MinifyThingConfigurableTick` if they're a part of the mod, and are regular `MinifiedThing` objects if not. Pre-existing minified objects are converted to `MinifyThingConfigurableTick`, if applicable, and respect the tick setting. No errors in the log, except when intentionally allowing ticks for items that shouldn't.

I've stripped the assembly changes out of this PR, but you can see them on [the original branch](https://github.com/Aussiemon/MinifyEverything/tree/minifiedTickingSubclass).

One caveat: If the mod is removed mid-save, the custom subclass objects are removed with it. This seems worth the performance improvement though, and MinifyEverything isn't always safe to remove anyway.

Before:

<img width="619" height="753" alt="image" src="https://github.com/user-attachments/assets/a7f70fd1-90da-44ba-be56-d3e64b23f851" />

After:

<img width="620" height="749" alt="image" src="https://github.com/user-attachments/assets/797eb40e-933c-48f7-a7ab-e43a8d34c97e" />
